### PR TITLE
a revised and expanded announcement for JME 3.3.2-stable

### DIFF
--- a/content/blog/jme332.md
+++ b/content/blog/jme332.md
@@ -1,0 +1,28 @@
+---
+title: "jMonkeyEngine 3.3.2 released"
+date: 2020-05-10T08:00:00+00:00
+draft: false
+type: "blog"
+layout: "post"
+
+authors:
+    - "ItsMike54"
+    - "sgold"
+
+tags:
+    - "development"
+    - "software"
+---
+
+JMonkeyEngine version 3.3.2 is here!
+
+After 3 months of beta testing, the Java game engine's long-awaited v3.3 release arrived on 30 March. With it came exciting new features:  AppState ids, light-probe blending, a better ragdoll control, and an animation system rewritten from the ground up.
+
+As often happens, a few key bugfixes missed the cutoff for v3.3.0-stable. In its wake, the JMonkeyEngine team came together and identified a handful of existing fixes that could be safely backported into v3.3.  With the help of volunteers, candidate builds received extensive testing on multiple platforms.  Their efforts culminated in version 3.3.2-stable, a production-ready patch release from the v3.3 line.
+ 
+The 3.3.2-stable libraries are tested, approved, and ready-to-rock!
+
+For projects built with Maven or Gradle, artifacts are available from JCenter.  If you are looking for the source code, go to https://github.com/jMonkeyEngine/jmonkeyengine/releases/tag/v3.3.2-stable
+
+At this time, version 3.3 of the JME Software Development Kit (based on Netbeans 11) is still undergoing testing and is not recommended for production use.  Until it's ready, development with the v3.3 libraries can proceed using the 3.2 SDK (based on Netbeans 8) or general-purpose IDEs such as IntelliJ IDEA.
+


### PR DESCRIPTION
I took what @ItsMike54 wrote for PR #4 and attempted to improve on it:
 + added background (on the 3.3 release and its features) to motivate v3.3.2
 + removed all mention of specific bugs (they're listed at the linked page on GitHub)
 + emphasized the team effort that went into the release
 + removed the Bintray URL and the (incorrect) claim that JARs are available there
 + distinguished the JME SDK from the Engine (a perennial source of confusion)